### PR TITLE
HEIF image format support

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Install dependent libraries"
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libwebp-dev
+          packages: libwebp-dev libheif-dev
           version: 1.0
 
       - name: "Setup Go"
@@ -49,7 +49,7 @@ jobs:
       - name: "Install dependent libraries"
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libwebp-dev
+          packages: libwebp-dev libheif-dev
           version: 1.0
 
       - name: "Setup Go"

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -80,6 +80,12 @@ jobs:
       - name: "Checkout Repo"
         uses: actions/checkout@v3
 
+      - name: "Install dependent libraries"
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libwebp-dev libheif-dev
+          version: 1.0
+
       - name: "Setup Go"
         uses: actions/setup-go@v4
         with:

--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ the cli tool is mostly focused on working with media files and to generate
 them.
 
 ### Dependencies
-Requires [libwebp](https://developers.google.com/speed/webp/docs/api) for webp image generation.
+Requires the following libraries:
+- [libwebp](https://developers.google.com/speed/webp/docs/api) for webp image generation.
+- [libheif](https://github.com/strukturag/libheif) for heif image generation.

--- a/cmd/spawn/main.go
+++ b/cmd/spawn/main.go
@@ -72,6 +72,8 @@ func imageCmd() *cli.Command {
 					q = 100
 				}
 				generator = &image.WebpGenerator{Quality: float32(q)}
+			case "heic":
+				generator = &image.HeifGenerator{}
 			default:
 				log.Fatalf("Invalid image mime type '%s' used", imgType)
 			}

--- a/cmd/spawn/main.go
+++ b/cmd/spawn/main.go
@@ -54,6 +54,10 @@ func imageCmd() *cli.Command {
 
 			dimen := &image.Dimens{Width: ctx.Uint("width"), Height: ctx.Uint("height")}
 			imgType := ctx.String("type")
+			q := ctx.Uint("quality")
+			if q > 100 {
+				q = 100
+			}
 
 			var generator image.Generator
 
@@ -61,19 +65,11 @@ func imageCmd() *cli.Command {
 			case "png":
 				generator = &image.PngGenerator{}
 			case "jpg", "jpeg":
-				q := ctx.Uint("quality")
-				if q > 100 {
-					q = 100
-				}
 				generator = &image.JpegGenerator{Quality: int(q)}
 			case "webp":
-				q := ctx.Uint("quality")
-				if q > 100 {
-					q = 100
-				}
 				generator = &image.WebpGenerator{Quality: float32(q)}
 			case "heic":
-				generator = &image.HeifGenerator{}
+				generator = &image.HeifGenerator{Quality: int(q)}
 			default:
 				log.Fatalf("Invalid image mime type '%s' used", imgType)
 			}

--- a/go.mod
+++ b/go.mod
@@ -2,16 +2,19 @@ module github.com/prajeenrg/spawn
 
 go 1.20
 
-require github.com/urfave/cli/v2 v2.25.1
+require (
+	github.com/kolesa-team/go-webp v1.0.4
+	github.com/schollz/progressbar/v3 v3.13.1
+	github.com/urfave/cli/v2 v2.25.1
+)
 
 require (
+	github.com/carck/libheif v1.12.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/kolesa-team/go-webp v1.0.4 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/schollz/progressbar/v3 v3.13.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
+github.com/carck/libheif v1.12.0 h1:j36qGDMuo6ZKXB6LS7nwMEBMpNEkCICVDF8b/f0mWqk=
+github.com/carck/libheif v1.12.0/go.mod h1:mGjF2fHRs36qK4l+MTEJFqqsr4gcYDvlRNtIgfT4Dk0=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/kolesa-team/go-webp v1.0.4 h1:wQvU4PLG/X7RS0vAeyhiivhLRoxfLVRlDq4I3frdxIQ=
@@ -10,6 +13,7 @@ github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWV
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -19,6 +23,7 @@ github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iH
 github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli/v2 v2.25.1 h1:zw8dSP7ghX0Gmm8vugrs6q9Ku0wzweqPyshy+syu9Gw=
 github.com/urfave/cli/v2 v2.25.1/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
@@ -34,3 +39,4 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/image/heif.go
+++ b/pkg/image/heif.go
@@ -1,0 +1,38 @@
+package image
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/carck/libheif/go/heif"
+	"github.com/prajeenrg/spawn/pkg/util"
+)
+
+type HeifGenerator struct{}
+
+func (h *HeifGenerator) SingleImage(name string, d *Dimens) {
+	image := generateImage(d)
+	ctx, err := heif.EncodeFromImage(image, heif.CompressionHEVC, 100, heif.LosslessModeEnabled, heif.LoggingLevelFull)
+
+	if err != nil {
+		log.Fatalln("Cannot create heif file from image")
+	}
+
+	if !util.CheckExtension(name, "heic") {
+		name = fmt.Sprintf("%s.heic", name)
+	}
+
+	if err := ctx.WriteToFile(name); err != nil {
+		log.Fatalln("Failed to write heif image")
+	}
+}
+
+func (h *HeifGenerator) MultipleImages(directory, prefix string, d *Dimens, count uint) {
+	util.CreateFolderIfNotExits(directory)
+	bar := util.GetProgressBar(count, "Generating WebP files")
+	for i := uint(1); i <= count; i++ {
+		filename := fmt.Sprintf("%s/%s_%dx%d_%d.heic", directory, prefix, d.Width, d.Height, i)
+		h.SingleImage(filename, d)
+		util.Increment(&bar)
+	}
+}

--- a/pkg/image/heif.go
+++ b/pkg/image/heif.go
@@ -8,17 +8,19 @@ import (
 	"github.com/prajeenrg/spawn/pkg/util"
 )
 
-type HeifGenerator struct{}
+type HeifGenerator struct {
+	Quality int
+}
 
 func (h *HeifGenerator) SingleImage(name string, d *Dimens) {
 	image := generateImage(d)
-	ctx, err := heif.EncodeFromImage(image, heif.CompressionHEVC, 100, heif.LosslessModeEnabled, heif.LoggingLevelFull)
+	ctx, err := heif.EncodeFromImage(image, heif.CompressionHEVC, h.Quality, heif.LosslessModeEnabled, heif.LoggingLevelFull)
 
 	if err != nil {
 		log.Fatalln("Cannot create heif file from image")
 	}
 
-	if !util.CheckExtension(name, "heic") {
+	if !util.CheckExtension(name, "heic") || !util.CheckExtension(name, "heif") {
 		name = fmt.Sprintf("%s.heic", name)
 	}
 
@@ -29,7 +31,7 @@ func (h *HeifGenerator) SingleImage(name string, d *Dimens) {
 
 func (h *HeifGenerator) MultipleImages(directory, prefix string, d *Dimens, count uint) {
 	util.CreateFolderIfNotExits(directory)
-	bar := util.GetProgressBar(count, "Generating WebP files")
+	bar := util.GetProgressBar(count, "Generating heif files")
 	for i := uint(1); i <= count; i++ {
 		filename := fmt.Sprintf("%s/%s_%dx%d_%d.heic", directory, prefix, d.Width, d.Height, i)
 		h.SingleImage(filename, d)

--- a/pkg/image/heif.go
+++ b/pkg/image/heif.go
@@ -13,8 +13,10 @@ type HeifGenerator struct {
 }
 
 func (h *HeifGenerator) SingleImage(name string, d *Dimens) {
-	image := generateImage(d)
-	ctx, err := heif.EncodeFromImage(image, heif.CompressionHEVC, h.Quality, heif.LosslessModeEnabled, heif.LoggingLevelFull)
+	nrgba := generateImage(d)
+	image := convertNrgbaToRgba(nrgba)
+
+	ctx, err := heif.EncodeFromImage(image, heif.CompressionHEVC, h.Quality, heif.LosslessModeEnabled, heif.LoggingLevelNone)
 
 	if err != nil {
 		log.Fatalln("Cannot create heif file from image")

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -3,6 +3,7 @@ package image
 import (
 	"image"
 	"image/color"
+	"image/draw"
 
 	"github.com/prajeenrg/spawn/pkg/util"
 )
@@ -15,6 +16,13 @@ type Dimens struct {
 type Generator interface {
 	SingleImage(string, *Dimens)
 	MultipleImages(string, string, *Dimens, uint)
+}
+
+func convertNrgbaToRgba(im image.Image) image.Image {
+	b := im.Bounds()
+	rgba := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+	draw.Draw(rgba, rgba.Bounds(), im, b.Min, draw.Src)
+	return rgba
 }
 
 func generateImage(d *Dimens) image.Image {


### PR DESCRIPTION
1. Add `heif` image generation capability
2. Add `heif` type support for `spawn image` subcommand
3. Update pipeline to install `libheif-dev` library
4. Fix pipeline not installing dep libraries on release build